### PR TITLE
 got rid of the red curly brace on the bottom of the recipe search page

### DIFF
--- a/dragon-fruit-recipes/client/src/pages/RecipeSearchPage.jsx
+++ b/dragon-fruit-recipes/client/src/pages/RecipeSearchPage.jsx
@@ -69,4 +69,3 @@ export default function RecipeSearch() {
         </>
     )
 
-}


### PR DESCRIPTION
fixed curly brace on recipe search page